### PR TITLE
Add LaTeX macros and option to pass quick_and_dirty

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The (copy of the) session is cleaned before building.
 
 If snippets are generated for more than one theory then the snippets are prefixed by the name of the theory.
 
+
+### Unfinished theories
+
+If one of your Isabelle theories contains a `sorry`, you will need to pass the option `-o quick_and_dirty` to Isabelle before it will compile your session.
+To do this, you can pass the option `-quick_and_dirty` to isasnips.
+
 Output
 ------
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If snippets are generated for more than one theory then the snippets are prefixe
 ### Unfinished theories
 
 If one of your Isabelle theories contains a `sorry`, you will need to pass the option `-o quick_and_dirty` to Isabelle before it will compile your session.
-To do this, you can pass the option `-quick_and_dirty` to isasnips.
+To do this, you can pass the option `-quick_and_dirty` (or `-quick-and-dirty`) to isasnips.
 
 Output
 ------

--- a/README.md
+++ b/README.md
@@ -113,16 +113,6 @@ Something like the following macros is needed to turn snippets into LaTeX comman
 ```
 \usepackage{isabelle, isabellesym}
 
-% Isabelle currently generates some undefined macros, so we just define them to be empty:
-\def\isadelimtheory{}\def\endisadelimtheory{}
-\def\isatagtheory{}\def\endisatagtheory{}
-\def\isadelimML{}\def\endisadelimML{}
-\def\isatagML{}\def\endisatagML{}
-\def\isafoldML{}
-\def\isadelimproof{}\def\endisadelimproof{}
-\def\isatagproof{}\def\endisatagproof{}
-\def\isafoldproof{}
-
 \isabellestyle{it} % optional
 \newcommand{\DefineSnippet}[2]{\expandafter\newcommand\csname snippet--#1\endcsname{#2}}
 \input{snips}
@@ -154,6 +144,19 @@ Something like the following macros is needed to turn snippets into LaTeX comman
     \else \repeat
 }}
 
+```
+
+Depending on your LaTeX template, you may also need the following lines, since Isabelle will sometimes generate macros that are not defined in a template:
+```
+% Isabelle currently generates some undefined macros, so we just define them to be empty:
+\def\isadelimtheory{}\def\endisadelimtheory{}
+\def\isatagtheory{}\def\endisatagtheory{}
+\def\isadelimML{}\def\endisadelimML{}
+\def\isatagML{}\def\endisatagML{}
+\def\isafoldML{}
+\def\isadelimproof{}\def\endisadelimproof{}
+\def\isatagproof{}\def\endisatagproof{}
+\def\isafoldproof{}
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ Something like the following macros is needed to turn snippets into LaTeX comman
 
 ```
 \usepackage{isabelle, isabellesym}
+
+% Isabelle currently generates some undefined macros, so we just define them to be empty:
+\def\isadelimtheory{}\def\endisadelimtheory{}
+\def\isatagtheory{}\def\endisatagtheory{}
+\def\isadelimML{}\def\endisadelimML{}
+\def\isatagML{}\def\endisatagML{}
+\def\isafoldML{}
+\def\isadelimproof{}\def\endisadelimproof{}
+\def\isatagproof{}\def\endisatagproof{}
+\def\isafoldproof{}
+
 \isabellestyle{it} % optional
 \newcommand{\DefineSnippet}[2]{\expandafter\newcommand\csname snippet--#1\endcsname{#2}}
 \input{snips}
@@ -136,6 +147,7 @@ Something like the following macros is needed to turn snippets into LaTeX comman
     \ifnum \i>#2 {}
     \else \repeat
 }}
+
 ```
 
 ### Examples

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,11 +509,12 @@ fn main() {
         exit(1);
     }
 
-    let quick_and_dirty = args.contains(&String::from("-quick_and_dirty"));
+    let quick_and_dirty = args.contains(&String::from("-quick_and_dirty"))
+	               || args.contains(&String::from("-quick-and-dirty"));
 
     let mut user_theories =
 	if quick_and_dirty {
-	    args.retain(|x| *x != "-quick_and_dirty");
+	    args.retain(|x| *x != "-quick_and_dirty" && *x != "-quick-and-dirty");
 	    args.iter().skip(3).map(OsString::from).collect::<Vec<_>>()
 	} else {
 	    args.iter().skip(3).map(OsString::from).collect::<Vec<_>>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,7 +499,7 @@ fn extract_snippets(path: &Path, theories: &[OsString]) -> io::Result<String> {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let mut args: Vec<String> = env::args().collect();
 
     if args.len() < 3 {
         println!(
@@ -509,7 +509,15 @@ fn main() {
         exit(1);
     }
 
-    let mut user_theories = args.iter().skip(3).map(OsString::from).collect::<Vec<_>>();
+    let quick_and_dirty = args.contains(&String::from("-quick_and_dirty"));
+
+    let mut user_theories =
+	if quick_and_dirty {
+	    args.retain(|x| *x != "-quick_and_dirty");
+	    args.iter().skip(3).map(OsString::from).collect::<Vec<_>>()
+	} else {
+	    args.iter().skip(3).map(OsString::from).collect::<Vec<_>>()
+	};
 
     let isa_path = Path::new(&args[1]);
     if !isa_path.exists() {
@@ -536,7 +544,11 @@ fn main() {
         }
     }
 
-    call_isabelle(temp_path, &["build", "-c", "-D", "."]).expect("Error running Isabelle build.");
+    if quick_and_dirty {
+	call_isabelle(temp_path, &["build", "-c", "-o", "quick_and_dirty", "-D", "."]).expect("Error running Isabelle build.");
+    } else {
+	call_isabelle(temp_path, &["build", "-c", "-D", "."]).expect("Error running Isabelle build.");
+    }
 
     println!("Extracting snippets for theories: {:?}", user_theories);
 


### PR DESCRIPTION
This PR is actually two separate changes.

First, Isabelle currently generates some LaTeX macros that are undefined, so the recommended LaTeX should include definitions for these macros.

Second, for unfinished theories, Isabelle needs the `quick_and_dirty` flag before it will build.
I have added a flag to isasnips that allows the user to pass this flag to Isabelle.